### PR TITLE
Add "browservice_quality" URL parameter to set initial quality.

### DIFF
--- a/viceplugins/retrojsvice/src/http.cpp
+++ b/viceplugins/retrojsvice/src/http.cpp
@@ -273,7 +273,6 @@ private:
     string path_;
     Poco::URI params_;
     string userAgent_;
-    
 
     unique_ptr<Poco::Net::HTMLForm> form_;
     map<string, shared_ptr<FileUpload>> files_;

--- a/viceplugins/retrojsvice/src/http.hpp
+++ b/viceplugins/retrojsvice/src/http.hpp
@@ -25,6 +25,7 @@ public:
 
     string method();
     string path();
+    string getQualityParam();
     string userAgent();
 
     // Form accessors return empty string/pointer if there is no entry with

--- a/viceplugins/retrojsvice/src/window_manager.cpp
+++ b/viceplugins/retrojsvice/src/window_manager.cpp
@@ -331,13 +331,27 @@ void WindowManager::handleNewWindowRequest_(MCE, shared_ptr<HTTPRequest> request
             REQUIRE(!windows_.count(handle));
 
             bool allowPNG = hasPNGSupport(request->userAgent());
+
+	    int quality = defaultQuality_;
+
+	    try {
+                int qualityParam = std::stoi(request->getQualityParam());
+	        if (qualityParam >= 10 && qualityParam <= 100) {
+	            allowPNG = false;
+	            quality = qualityParam;
+		}
+	    }
+	    catch (...) {
+                WARNING_LOG("Invalid quality parameter");
+	    }
+
             shared_ptr<Window> window = Window::create(
                 shared_from_this(),
                 handle,
                 secretGen_,
                 programName_,
                 allowPNG,
-                defaultQuality_
+                quality
             );
             REQUIRE(windows_.emplace(handle, window).second);
 


### PR DESCRIPTION
Not sure if you actually want to merge this, but figured I'd give you the option.

I've found that on my Pentium II 400 machine using Internet Explorer 5, browsing works great, but is much more responsive with something like a 90 quality setting instead of PNG. Instead of setting it manually every time I open a window, I use this change to set it for me. 

C++ isn't exactly my wheelhouse, so I apologize for the messiness. 